### PR TITLE
Fix breaking whitespace in path name

### DIFF
--- a/tasks/kss.js
+++ b/tasks/kss.js
@@ -34,8 +34,13 @@ module.exports = function (grunt) {
     kssCmd.push(realPath + 'node_modules/kss/bin/kss-node');
 
     this.files.forEach(function (file) {
-      kssCmd.push("\"" + file.src[0] + "\"");
-      kssCmd.push("\"" + file.dest + "\"");
+      // TODO removed the quotation wrapping, but there is not an issue of white space in
+      // folder paths.
+      //
+      // Removed the quotation wrapping because it was causing paths like this to be used
+      // by KSS: /usr/home/"my_folder"
+      kssCmd.push(file.src[0]);
+      kssCmd.push(file.dest);
       dest = file.dest;
     });
 

--- a/tasks/kss.js
+++ b/tasks/kss.js
@@ -31,16 +31,11 @@ module.exports = function (grunt) {
       config: null
     });
 
-    kssCmd.push(realPath + 'node_modules/kss/bin/kss-node');
+    kssCmd.push("\"" + realPath + 'node_modules/kss/bin/kss-node"');
 
     this.files.forEach(function (file) {
-      // TODO removed the quotation wrapping, but there is not an issue of white space in
-      // folder paths.
-      //
-      // Removed the quotation wrapping because it was causing paths like this to be used
-      // by KSS: /usr/home/"my_folder"
-      kssCmd.push(file.src[0]);
-      kssCmd.push(file.dest);
+      kssCmd.push("\"" + file.src[0] + "\"");
+      kssCmd.push("\"" + file.dest + "\"");
       dest = file.dest;
     });
 


### PR DESCRIPTION
If the path has a space in it, then it will look like multiple parameters to kss when we pass our kssCmd to it. This simply wraps the path is quotes so that it will still be interpreted as a single parameter.

Close #29.